### PR TITLE
Replace search for zero byte with memchr()

### DIFF
--- a/minimp4.h
+++ b/minimp4.h
@@ -2171,7 +2171,8 @@ static const uint8_t *find_start_code(const uint8_t *h264_data, int h264_data_by
     do
     {
         int zero_cnt = 1;
-        while (p < eof && *p) p++;
+        const uint8_t* found = (uint8_t*)memchr(p, 0, eof - p);
+        p = (found != nullptr) ? found : eof;
         while (p + zero_cnt < eof && !p[zero_cnt]) zero_cnt++;
         if (zero_cnt >= 2 && p[zero_cnt] == 1)
         {


### PR DESCRIPTION
While profiling minimp4 during MP4 encoding, find_start_code showed up as the most expensive function. Specifically, the first while loop searching for an initial zero byte. This is effectively what memchr() does, and glibc includes an optimized version of this method. Switching to memchr() showed a performance improvement in this method.