### PR TITLE
Add tag to mp4_h26x_writer_t

### DIFF
--- a/minimp4.h
+++ b/minimp4.h
@@ -329,7 +329,7 @@ typedef struct
 
 } h264_sps_id_patcher_t;
 
-typedef struct
+typedef struct mp4_h26x_writer_tag
 {
 #if MINIMP4_TRANSCODE_SPS_ID
     h264_sps_id_patcher_t sps_patcher;


### PR DESCRIPTION
A change that allows forward declaration of mp4_h26x_writer_t struct in C++