### PR TITLE
fix access unit delimiter handling

### DIFF
--- a/minimp4.h
+++ b/minimp4.h
@@ -2340,7 +2340,7 @@ int mp4_h26x_write_nal(mp4_h26x_writer_t *h, const unsigned char *nal, int lengt
         }
         payload_type = nal[0] & 31;
         if (9 == payload_type)
-            return err; /* access unit delimiter */
+            continue;  // access unit delimiter, nothing to be done
 #if MINIMP4_TRANSCODE_SPS_ID
         // Transcode SPS, PPS and slice headers, reassigning ID's for SPS and  PPS:
         // - assign unique ID's to different SPS and PPS


### PR DESCRIPTION
As per discussion in #27, this PR correctly handles type 9 NAL units.