### PR TITLE
Add function to find sync frames and store avc1 codec information

### DIFF
--- a/minimp4.h
+++ b/minimp4.h
@@ -176,6 +176,12 @@ typedef struct
     // The 'sample' is MP4 term, denoting audio or video frame
     unsigned sample_count;
 
+    // Elementary Stream Descriptor (ESDS) data offset
+    unsigned esds_offset;
+
+    // ESDS data size
+    unsigned esds_bytes;
+
     // Decoder-specific info (DSI) data
     unsigned char *dsi;
 
@@ -3065,6 +3071,15 @@ broken_android_meta_hack:
             // for BOX_mp4v:
             //      BOX_esds
             break;
+
+        case BOX_esds:
+            assert(tr);
+            if (!tr->esds_offset && payload_bytes) {
+                // Don't affect the parsing of OD boxes by just storing the offset
+                tr->esds_offset = (unsigned)mp4->read_pos;
+                tr->esds_bytes = (unsigned)payload_bytes;
+                break;
+            }
 
         case BOX_avcC:  // AVCDecoderConfigurationRecord()
             // hack: AAC-specific DSI field reused (for it have same purpoose as sps/pps)

--- a/minimp4.h
+++ b/minimp4.h
@@ -386,13 +386,14 @@ int MP4D_open(MP4D_demux_t *mp4, int (*read_callback)(int64_t offset, void *buff
 *   MP4 term for 'frame'
 *
 *   frame_bytes [OUT]   - return coded frame size in bytes
-*   timestamp [OUT]     - return frame timestamp (in mp4->timescale units)
+*   dts [OUT]           - return frame decoding timestamp (in mp4->timescale units)
+*   pts [OUT]           - return frame presentation timestamp (in mp4->timescale units)
 *   duration [OUT]      - return frame duration (in mp4->timescale units)
 *   is_sync [OUT]       - return if frame is a sync frame
 *
 *   function return offset for the frame
 */
-MP4D_file_offset_t MP4D_frame_offset(const MP4D_demux_t *mp4, unsigned int ntrack, unsigned int nsample, unsigned int *frame_bytes, unsigned *timestamp, unsigned *duration, int *is_sync);
+MP4D_file_offset_t MP4D_frame_offset(const MP4D_demux_t *mp4, unsigned ntrack, unsigned nsample, unsigned *frame_bytes, unsigned *dts, unsigned *pts, unsigned *duration, int *is_sync);
 
 /**
 *   Find the nearest sync frame.

--- a/minimp4.h
+++ b/minimp4.h
@@ -3327,7 +3327,7 @@ MP4D_file_offset_t MP4D_frame_offset(const MP4D_demux_t *mp4, unsigned ntrack, u
     if (pts)
     {
 #if MP4D_TIMESTAMPS_SUPPORTED
-        *pts = tr->comp_timestamp[ns];
+        *pts = tr->comp_timestamp ? tr->comp_timestamp[ns] : tr->timestamp[ns];
 #else
         *pts = 0;
 #endif

--- a/minimp4.h
+++ b/minimp4.h
@@ -153,6 +153,7 @@ typedef struct
         {
             // number of channels in the audio track.
             unsigned channelcount;
+            unsigned samplerate_hz;
         } a;
 
         struct
@@ -1446,7 +1447,7 @@ static int mp4e_flush_index(MP4E_mux_t *mux)
                                 WRITE_2(tr->info.u.a.channelcount); // channelcount
                                 WRITE_2(16); // samplesize
                                 WRITE_4(0);  // pre_defined+reserved
-                                WRITE_4((tr->info.time_scale << 16));  // samplerate == = {timescale of media}<<16;
+                                WRITE_4((tr->info.u.a.samplerate_hz << 16));  // samplerate
                             }
 
                                 ATOM_FULL(BOX_esds, 0);

--- a/minimp4.h
+++ b/minimp4.h
@@ -584,6 +584,7 @@ enum
     BOX_vmhd    = FOUR_CHAR_INT( 'v', 'm', 'h', 'd' ),//VideoMediaHeaderAtomType
     BOX_url     = FOUR_CHAR_INT( 'u', 'r', 'l', ' ' ),
     BOX_urn     = FOUR_CHAR_INT( 'u', 'r', 'n', ' ' ),
+    BOX_colr    = FOUR_CHAR_INT( 'c', 'o', 'l', 'r' ),
 
     BOX_gnrv    = FOUR_CHAR_INT( 'g', 'n', 'r', 'v' ),//GenericVisualSampleEntryAtomType
     BOX_gnra    = FOUR_CHAR_INT( 'g', 'n', 'r', 'a' ),//GenericAudioSampleEntryAtomType
@@ -3273,6 +3274,19 @@ broken_android_meta_hack:
             }
             break;
 #endif
+
+        case BOX_colr:
+            {
+                unsigned color_type = READ(4);
+                if (color_type == FOUR_CHAR_INT('n', 'c', 'l', 'x')) {
+                    unsigned color_primaries = READ(2);
+                    unsigned transfer_characteristics = READ(2);
+                    unsigned matrix_coefficients = READ(2);
+                    unsigned full_range_flag = READ(1) >> 7;
+                }
+                SKIP(payload_bytes);
+                break;
+            }
 
         case OD_ESD:
             {

--- a/minimp4.h
+++ b/minimp4.h
@@ -2625,7 +2625,7 @@ int MP4D_open(MP4D_demux_t *mp4, int (*read_callback)(int64_t offset, void *buff
 #endif
 #if MP4D_TRACE_TIMESTAMPS
             {BOX_stts, 0, 0},
-            {BOX_ctts, 0, 0},
+            {BOX_ctts, 1, 0},
 #endif
             {BOX_stz2, 0, 1},
             {BOX_stsz, 0, 1},

--- a/minimp4.h
+++ b/minimp4.h
@@ -652,7 +652,7 @@ enum
     BOX_meta   = FOUR_CHAR_INT( 'm', 'e', 't', 'a' ),
     BOX_ilst   = FOUR_CHAR_INT( 'i', 'l', 's', 't' ),
 
-    // Metagata tags, see http://atomicparsley.sourceforge.net/mpeg-4files.html
+    // Metadata tags, see http://atomicparsley.sourceforge.net/mpeg-4files.html
     BOX_calb    = FOUR_CHAR_INT( '\xa9', 'a', 'l', 'b'),    // album
     BOX_cart    = FOUR_CHAR_INT( '\xa9', 'a', 'r', 't'),    // artist
     BOX_aART    = FOUR_CHAR_INT( 'a', 'A', 'R', 'T' ),      // album artist
@@ -3410,8 +3410,13 @@ broken_android_meta_hack:
 
         // remove empty boxes from stack
         // don't touch box with index 0 (which indicates whole file)
-        while (depth > 0 && !stack[depth].bytes)
+        while (depth > 0 && stack[depth].bytes < 8)
         {
+            boxsize_t padding = stack[depth].bytes;
+            if (padding)
+            {
+                mp4->read_pos += padding;
+            }
             depth--;
         }
 

--- a/minimp4.h
+++ b/minimp4.h
@@ -3413,7 +3413,7 @@ broken_android_meta_hack:
 
         // remove empty boxes from stack
         // don't touch box with index 0 (which indicates whole file)
-        while (depth > 0 && stack[depth].bytes < 8)
+        while (depth > 0 && (stack[depth].bytes == 0 || (stack[depth].format == BOX_ATOM && stack[depth].bytes < 8)))
         {
             boxsize_t padding = stack[depth].bytes;
             if (padding)

--- a/minimp4.h
+++ b/minimp4.h
@@ -233,8 +233,10 @@ typedef struct
     // Track language: 3-char ISO 639-2T code: "und", "eng", "rus", "jpn" etc...
     unsigned char language[4];
 
-    // Transformation matrix
+    // Transformation matrix and target width and height
     float matrix[9];
+    float width;
+    float height;
 
     // MP4 stream type
     // case 0x00: return "Forbidden";
@@ -3062,7 +3064,8 @@ broken_android_meta_hack:
                 tr->matrix[7] = fixedToFloat(READ(4), 16);
                 tr->matrix[8] = fixedToFloat(READ(4), 30);
 
-                SKIP(4 + 4);
+                tr->width = fixedToFloat(READ(4), 16);
+                tr->height = fixedToFloat(READ(4), 16);
 
                 break;
             }

--- a/minimp4.h
+++ b/minimp4.h
@@ -2989,8 +2989,13 @@ broken_android_meta_hack:
             break;
 
         case BOX_hdlr:
-            if (tr) // When this box is within 'meta' box, the track may not be avaialable
+            if (tr) // When this box is within 'meta' box, the track may not be available
             {
+                // Without this check the trak/mdia/minf/hdlr could overwrite our trak/mdia/hdlr.
+                if (tr->handler_type == MP4D_HANDLER_TYPE_VIDE || tr->handler_type == MP4D_HANDLER_TYPE_SOUN)
+                {
+                    break; // Skip
+                }
                 SKIP(4); // pre_defined
                 tr->handler_type = READ(4);
             }

--- a/minimp4.h
+++ b/minimp4.h
@@ -259,9 +259,11 @@ typedef struct
     union
     {
         struct {
+            unsigned char configurationVersion;
             unsigned char AVCProfileIndication;
             unsigned char profile_compatibility;
             unsigned char AVCLevelIndication;
+            unsigned char lengthSizeMinusOne;
         } avc1;
     } CodecDescription;
 #endif
@@ -3063,15 +3065,15 @@ broken_android_meta_hack:
                 //bit(6) reserved =
                 unsigned int lengthSizeMinusOne = READ(1) & 3;
 
-                (void)configurationVersion;
+                tr->CodecDescription.avc1.configurationVersion = configurationVersion;
                 tr->CodecDescription.avc1.AVCProfileIndication = AVCProfileIndication;
                 tr->CodecDescription.avc1.profile_compatibility = profile_compatibility;
                 tr->CodecDescription.avc1.AVCLevelIndication = AVCLevelIndication;
-                (void)lengthSizeMinusOne;
+                tr->CodecDescription.avc1.lengthSizeMinusOne = lengthSizeMinusOne;
 
                 for (spspps = 0; spspps < 2; spspps++)
                 {
-                    unsigned int numOfSequenceParameterSets= READ(1);
+                    unsigned int numOfSequenceParameterSets = READ(1);
                     if (!spspps)
                     {
                          numOfSequenceParameterSets &= 31;  // clears 3 msb for SPS

--- a/minimp4.h
+++ b/minimp4.h
@@ -255,6 +255,15 @@ typedef struct
             unsigned height;
         } video;
     } SampleDescription;
+
+    union
+    {
+        struct {
+            unsigned char AVCProfileIndication;
+            unsigned char profile_compatibility;
+            unsigned char AVCLevelIndication;
+        } avc1;
+    } CodecDescription;
 #endif
 
     /************************************************************************/
@@ -3055,9 +3064,9 @@ broken_android_meta_hack:
                 unsigned int lengthSizeMinusOne = READ(1) & 3;
 
                 (void)configurationVersion;
-                (void)AVCProfileIndication;
-                (void)profile_compatibility;
-                (void)AVCLevelIndication;
+                tr->CodecDescription.avc1.AVCProfileIndication = AVCProfileIndication;
+                tr->CodecDescription.avc1.profile_compatibility = profile_compatibility;
+                tr->CodecDescription.avc1.AVCLevelIndication = AVCLevelIndication;
                 (void)lengthSizeMinusOne;
 
                 for (spspps = 0; spspps < 2; spspps++)

--- a/minimp4_test.c
+++ b/minimp4_test.c
@@ -105,7 +105,8 @@ int demux(uint8_t *input_buf, ssize_t input_size, FILE *fout, int ntrack)
             for (i = 0; i < mp4.track[ntrack].sample_count; i++)
             {
                 unsigned frame_bytes, timestamp, duration;
-                MP4D_file_offset_t ofs = MP4D_frame_offset(&mp4, ntrack, i, &frame_bytes, &timestamp, &duration);
+                int is_sync;
+                MP4D_file_offset_t ofs = MP4D_frame_offset(&mp4, ntrack, i, &frame_bytes, &timestamp, &duration, &is_sync);
                 uint8_t *mem = input_buf + ofs;
                 sum_duration += duration;
                 while (frame_bytes)
@@ -138,7 +139,8 @@ int demux(uint8_t *input_buf, ssize_t input_size, FILE *fout, int ntrack)
             for (i = 0; i < mp4.track[ntrack].sample_count; i++)
             {
                 unsigned frame_bytes, timestamp, duration;
-                MP4D_file_offset_t ofs = MP4D_frame_offset(&mp4, ntrack, i, &frame_bytes, &timestamp, &duration);
+                int is_sync;
+                MP4D_file_offset_t ofs = MP4D_frame_offset(&mp4, ntrack, i, &frame_bytes, &timestamp, &duration, &is_sync);
                 printf("ofs=%d frame_bytes=%d timestamp=%d duration=%d\n", (unsigned)ofs, frame_bytes, timestamp, duration);
 #if ENABLE_AUDIO
                 UCHAR *frame = (UCHAR *)(input_buf + ofs);

--- a/minimp4_test.c
+++ b/minimp4_test.c
@@ -274,6 +274,7 @@ int main(int argc, char **argv)
     tr.time_scale = 90000;
     tr.default_duration = 0;
     tr.u.a.channelcount = 1;
+    tr.u.a.samplerate_hz = AUDIO_RATE;
     int audio_track_id = MP4E_add_track(mux, &tr);
     MP4E_set_dsi(mux, audio_track_id, info.confBuf, info.confSize);
 #endif

--- a/minimp4_test.c
+++ b/minimp4_test.c
@@ -89,14 +89,14 @@ int demux(uint8_t *input_buf, ssize_t input_size, FILE *fout, int ntrack)
         {   // assume h264
 #define USE_SHORT_SYNC 0
             char sync[4] = { 0, 0, 0, 1 };
-            while (spspps = MP4D_read_sps(&mp4, ntrack, i, &spspps_bytes))
+            while ((spspps = MP4D_read_sps(&mp4, ntrack, i, &spspps_bytes)))
             {
                 fwrite(sync + USE_SHORT_SYNC, 1, 4 - USE_SHORT_SYNC, fout);
                 fwrite(spspps, 1, spspps_bytes, fout);
                 i++;
             }
             i = 0;
-            while (spspps = MP4D_read_pps(&mp4, ntrack, i, &spspps_bytes))
+            while ((spspps = MP4D_read_pps(&mp4, ntrack, i, &spspps_bytes)))
             {
                 fwrite(sync + USE_SHORT_SYNC, 1, 4 - USE_SHORT_SYNC, fout);
                 fwrite(spspps, 1, spspps_bytes, fout);
@@ -106,7 +106,7 @@ int demux(uint8_t *input_buf, ssize_t input_size, FILE *fout, int ntrack)
             {
                 unsigned frame_bytes, timestamp, duration;
                 int is_sync;
-                MP4D_file_offset_t ofs = MP4D_frame_offset(&mp4, ntrack, i, &frame_bytes, &timestamp, &duration, &is_sync);
+                MP4D_file_offset_t ofs = MP4D_frame_offset(&mp4, ntrack, i, &frame_bytes, &timestamp, NULL, &duration, &is_sync);
                 uint8_t *mem = input_buf + ofs;
                 sum_duration += duration;
                 while (frame_bytes)
@@ -140,7 +140,7 @@ int demux(uint8_t *input_buf, ssize_t input_size, FILE *fout, int ntrack)
             {
                 unsigned frame_bytes, timestamp, duration;
                 int is_sync;
-                MP4D_file_offset_t ofs = MP4D_frame_offset(&mp4, ntrack, i, &frame_bytes, &timestamp, &duration, &is_sync);
+                MP4D_file_offset_t ofs = MP4D_frame_offset(&mp4, ntrack, i, &frame_bytes, &timestamp, NULL, &duration, &is_sync);
                 printf("ofs=%d frame_bytes=%d timestamp=%d duration=%d\n", (unsigned)ofs, frame_bytes, timestamp, duration);
 #if ENABLE_AUDIO
                 UCHAR *frame = (UCHAR *)(input_buf + ofs);


### PR DESCRIPTION
These are actually 3 commits. The first fixes warnings (mainly signedness comparisons and unused stuff). The second adds `MP4D_nearest_sync_frame` which lets you find the nearest key/sync frame given any frame in the video stream. This is useful when implementing random access functionality and you want to start on a key frame. The third commit stores avc1 codec information. The WebCodecs API requires a valid codec string. To build this string you need the three bytes from the `AVCDecoderConfigurationRecord`. Maybe in the future we could also add a function to generate this string. :)

Please let me know if this ok or I should submit separate PRs.